### PR TITLE
feat(client): allow env setup.

### DIFF
--- a/internal/tg/client.go
+++ b/internal/tg/client.go
@@ -17,10 +17,12 @@ func New(appID int, appHash, sessionPath string) *Client {
 }
 
 func (c *Client) T() *telegram.Client {
-	return telegram.NewClient(c.appID, c.appHash, telegram.Options{
+	opts := telegram.Options{
 		SessionStorage: &telegram.FileSessionStorage{
 			Path: c.sessionPath,
 		},
 		NoUpdates: true,
-	})
+	}
+	opts, _ = telegram.OptionsFromEnvironment(opts)
+	return telegram.NewClient(c.appID, c.appHash, opts)
 }


### PR DESCRIPTION
This change allows the mcp server to connect to the telegram api, when behind a proxy with the usage of the `ALL_PROXY` environment variable.
Reference: 
https://github.com/gotd/td/blob/5fc93520170a2367ed4b5fc6bc5821f1ef7abadb/telegram/builder.go#L45