### PR TITLE
Force JSON Schema Draft-07 for MCP tool compatibility with VSCode

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -8,11 +8,23 @@ import (
 
 	"github.com/chaindead/telegram-mcp/internal/tg"
 
+	"github.com/invopop/jsonschema"
 	mcp "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/mcp-golang/transport/stdio"
 	"github.com/rs/zerolog/log"
 	"github.com/urfave/cli/v3"
 )
+
+const jsonSchemaDraft07 = "https://json-schema.org/draft-07/schema#"
+
+func init() {
+	// MCP clients like VS Code currently ship JSON Schema validators that only
+	// understand draft-07. The default generator in github.com/invopop/jsonschema
+	// emits draft 2020-12 metadata, which triggers runtime warnings about
+	// unsupported $dynamicRef usage. Force the generator to emit draft-07 schemas
+	// so the Telegram tools remain usable across clients.
+	jsonschema.Version = jsonSchemaDraft07
+}
 
 func serve(ctx context.Context, cmd *cli.Command) error {
 	appID := cmd.Int("app-id")


### PR DESCRIPTION
This PR fixes (https://github.com/chaindead/telegram-mcp/issues/6) an issue where MCP tool schemas generated by github.com/invopop/jsonschema used JSON Schema Draft 2020-12 features (notably $dynamicRef), which are not supported by VS Code. This caused runtime warnings and prevented the Telegram MCP tools from working in VSCode.

**Patch:**

Added an override in serve.go to force the schema generator to emit Draft-07 schemas:
```go
import "github.com/invopop/jsonschema"

const jsonSchemaDraft07 = "https://json-schema.org/draft-07/schema#"

func init() {
    jsonschema.Version = jsonSchemaDraft07
}
```

**How to build:**
```bash
go build -o bin/telegram-mcp ./
```

Run the server and authenticate:
```bash
./bin/telegram-mcp auth --app-id <your-app-id> --api-hash <your-api-hash> --phone <your-phone> --password <your-2fa-password> --new
```

Use this MCP entry in VSCode (replace with your pathname or add it to your $PATH)

```json
 	"telegram": {
			"command": "/opt/telegram-mcp/bin/telegram-mcp",
			"env": {
				"TG_APP_ID": "XXXXX",
				"TG_API_HASH": "YYYYY"
			},
			"type": "stdio"
		}
```



