### PR TITLE
feat: Add option to send messages directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The Model Context Protocol (MCP) is a system that lets AI apps, like Claude Desk
 - [x] List dialogs with optional unread filter (`tool: tg_dialogs`)
 - [x] Mark dialog as read (`tool: tg_read`)
 - [x] Retrieve messages from specific dialog (`tool: tg_dialog`)
-- [x] Send draft messages to any dialog (`tool: tg_send`)
+- [x] Send messages or drafts to any dialog (`tool: tg_send`, set `send: true` to deliver immediately)
 
 ### Prompt examples
 

--- a/internal/tg/draft.go
+++ b/internal/tg/draft.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/gotd/td/telegram/message"
 	"github.com/gotd/td/tg"
 	mcp "github.com/metoro-io/mcp-golang"
 	"github.com/pkg/errors"
@@ -13,14 +14,19 @@ import (
 type DraftArguments struct {
 	Name string `json:"name" jsonschema:"required,description=Name of the dialog"`
 	Text string `json:"text" jsonschema:"required,description=Plain text of the message"`
+	Send bool   `json:"send,omitempty" jsonschema:"description=Send message immediately instead of saving as draft"`
 }
 
 type DraftResponse struct {
 	Success bool `json:"success"`
+	Sent    bool `json:"sent,omitempty"`
 }
 
 func (c *Client) SendDraft(args DraftArguments) (*mcp.ToolResponse, error) {
-	var ok bool
+	var (
+		ok   bool
+		sent bool
+	)
 	client := c.T()
 	if err := client.Run(context.Background(), func(ctx context.Context) (err error) {
 		api := client.API()
@@ -30,20 +36,32 @@ func (c *Client) SendDraft(args DraftArguments) (*mcp.ToolResponse, error) {
 			return fmt.Errorf("get inputPeer from name: %w", err)
 		}
 
+		if args.Send {
+			sender := message.NewSender(api)
+			if _, err = sender.To(inputPeer).Text(ctx, args.Text); err != nil {
+				return fmt.Errorf("send message: %w", err)
+			}
+
+			ok = true
+			sent = true
+
+			return nil
+		}
+
 		ok, err = api.MessagesSaveDraft(ctx, &tg.MessagesSaveDraftRequest{
 			Peer:    inputPeer,
 			Message: args.Text,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to get history: %w", err)
+			return fmt.Errorf("save draft: %w", err)
 		}
 
 		return nil
 	}); err != nil {
-		return nil, errors.Wrap(err, "failed to get history")
+		return nil, errors.Wrap(err, "failed to send message")
 	}
 
-	jsonData, err := json.Marshal(DraftResponse{Success: ok})
+	jsonData, err := json.Marshal(DraftResponse{Success: ok, Sent: sent})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to marshal response")
 	}

--- a/serve.go
+++ b/serve.go
@@ -97,7 +97,7 @@ func serve(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("register dialogs tool: %w", err)
 	}
 
-	err = server.RegisterTool("tg_send", "Send draft message to dialog", client.SendDraft)
+        err = server.RegisterTool("tg_send", "Send a message or draft to a dialog", client.SendDraft)
 	if err != nil {
 		return fmt.Errorf("register dialogs tool: %w", err)
 	}


### PR DESCRIPTION
## Summary
- add a `send` flag to the `tg_send` tool so messages can be delivered immediately
- update tool registration and documentation to reflect direct sending support
