### PR TITLE
fix: make JSON Schema version configurable to support VS Code and other clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The server is a bridge between the Telegram API and the AI assistants and is bas
 - [Configuration](#configuration)
   - [Authorization](#authorization)
   - [Client Configuration](#client-configuration)
+  - [JSON Schema Version](#json-schema-version)
 - [Star History](#star-history)
 
 ## What is MCP?
@@ -262,6 +263,16 @@ Example of Configuring Claude Desktop to recognize the Telegram MCP server.
       }
     }
     ```
+
+### JSON Schema Version
+
+Some MCP clients (e.g. VS Code) do not support JSON Schema Draft 2020-12 and will reject tools that use it. You can override the JSON Schema version by setting the `--schema-version` flag or the `TG_SCHEMA_VERSION` environment variable.
+
+Common values:
+| Version | URL |
+|---------|-----|
+| Draft-07 (recommended for VS Code) | `https://json-schema.org/draft-07/schema#` |
+| Draft 2020-12 (default) | `https://json-schema.org/draft/2020-12/schema` |
 
 ## Star History
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24
 
 require (
 	github.com/gotd/td v0.121.0
+	github.com/invopop/jsonschema v0.12.0
 	github.com/metoro-io/mcp-golang v0.8.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.34.0
@@ -28,7 +29,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gotd/ige v0.2.2 // indirect
 	github.com/gotd/neo v0.1.5 // indirect
-	github.com/invopop/jsonschema v0.12.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/main.go
+++ b/main.go
@@ -59,6 +59,11 @@ func main() {
 				Value:   sesionPath,
 				Sources: cli.EnvVars("TG_SESSION_PATH"),
 			},
+			&cli.StringFlag{
+				Name:    "schema-version",
+				Usage:   "JSON Schema version URL (e.g. https://json-schema.org/draft-07/schema#)",
+				Sources: cli.EnvVars("TG_SCHEMA_VERSION"),
+			},
 			&cli.BoolFlag{
 				Name:        "dry",
 				Usage:       "Test configuration",

--- a/serve.go
+++ b/serve.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/chaindead/telegram-mcp/internal/tg"
+	"github.com/invopop/jsonschema"
 
 	mcp "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/mcp-golang/transport/stdio"
@@ -19,6 +20,10 @@ func serve(ctx context.Context, cmd *cli.Command) error {
 	appHash := cmd.String("api-hash")
 	sessionPath := cmd.String("session")
 	dryRun := cmd.Bool("dry")
+
+	if schemaURL := cmd.String("schema-version"); schemaURL != "" {
+		jsonschema.Version = schemaURL
+	}
 
 	_, err := os.Stat(sessionPath)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #6 — VS Code rejects all 5 MCP tools because the default JSON Schema Draft 2020-12 (`$dynamicRef`) is not supported by its validator.

Instead of hardcoding Draft-07 (as proposed in #11), this PR makes the schema version **configurable** via:
- `--schema-version` CLI flag
- `TG_SCHEMA_VERSION` environment variable

This preserves the default behavior (Draft 2020-12) for clients that support it while allowing users who need Draft-07 (e.g. VS Code) to opt in.

## Changes

- **`main.go`**: Added `--schema-version` CLI flag sourced from `TG_SCHEMA_VERSION` env var
- **`serve.go`**: Import `invopop/jsonschema` directly; set `jsonschema.Version` when flag is provided
- **`go.mod`**: Promoted `invopop/jsonschema` from indirect to direct dependency
- **`README.md`**: Added "JSON Schema Version" section with usage examples and common values table

## Usage

```json
{
  "mcpServers": {
    "telegram": {
      "command": "telegram-mcp",
      "args": ["--schema-version", "https://json-schema.org/draft-07/schema#"],
      "env": {
        "TG_SESSION_PATH": "path/to/session"
      }
    }
  }
}
```

Or via environment variable:

```bash
TG_SCHEMA_VERSION="https://json-schema.org/draft-07/schema#" telegram-mcp
```