### PR TITLE
feat: add real message sending, rename draft tool, fix auth proxy

### DIFF
--- a/internal/tg/auth.go
+++ b/internal/tg/auth.go
@@ -19,11 +19,13 @@ func Auth(phone string, appID int64, appHash string, sessionPath string, passwor
 		_ = os.Remove(sessionPath)
 	}
 
-	client := telegram.NewClient(int(appID), appHash, telegram.Options{
+	opts := telegram.Options{
 		SessionStorage: &telegram.FileSessionStorage{
 			Path: sessionPath,
 		},
-	})
+	}
+	opts, _ = telegram.OptionsFromEnvironment(opts)
+	client := telegram.NewClient(int(appID), appHash, opts)
 
 	sessionDir := filepath.Dir(sessionPath)
 	if err := os.MkdirAll(sessionDir, 0700); err != nil {

--- a/internal/tg/send.go
+++ b/internal/tg/send.go
@@ -1,0 +1,71 @@
+package tg
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	"github.com/gotd/td/tg"
+	mcp "github.com/metoro-io/mcp-golang"
+	"github.com/pkg/errors"
+)
+
+type SendArguments struct {
+	Name    string `json:"name" jsonschema:"required,description=Name of the dialog"`
+	Text    string `json:"text" jsonschema:"required,description=Plain text of the message"`
+	ReplyTo int    `json:"reply_to,omitempty" jsonschema:"description=Message ID to reply to"`
+}
+
+type SendResponse struct {
+	Success bool `json:"success"`
+}
+
+func (c *Client) SendMessage(args SendArguments) (*mcp.ToolResponse, error) {
+	var success bool
+	client := c.T()
+
+	if err := client.Run(context.Background(), func(ctx context.Context) (err error) {
+		api := client.API()
+
+		inputPeer, err := getInputPeerFromName(ctx, api, args.Name)
+		if err != nil {
+			return fmt.Errorf("get inputPeer from name: %w", err)
+		}
+
+		n, err := rand.Int(rand.Reader, big.NewInt(1<<62))
+		if err != nil {
+			return fmt.Errorf("generate random ID: %w", err)
+		}
+
+		req := &tg.MessagesSendMessageRequest{
+			Peer:     inputPeer,
+			Message:  args.Text,
+			RandomID: n.Int64(),
+		}
+
+		if args.ReplyTo > 0 {
+			req.ReplyTo = &tg.InputReplyToMessage{
+				ReplyToMsgID: args.ReplyTo,
+			}
+		}
+
+		_, err = api.MessagesSendMessage(ctx, req)
+		if err != nil {
+			return fmt.Errorf("send message: %w", err)
+		}
+
+		success = true
+		return nil
+	}); err != nil {
+		return nil, errors.Wrap(err, "failed to send message")
+	}
+
+	jsonData, err := json.Marshal(SendResponse{Success: success})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal response")
+	}
+
+	return mcp.NewToolResponse(mcp.NewTextContent(string(jsonData))), nil
+}

--- a/serve.go
+++ b/serve.go
@@ -102,9 +102,14 @@ func serve(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("register dialogs tool: %w", err)
 	}
 
-	err = server.RegisterTool("tg_send", "Send draft message to dialog", client.SendDraft)
+	err = server.RegisterTool("tg_draft", "Save draft message to dialog", client.SendDraft)
 	if err != nil {
-		return fmt.Errorf("register dialogs tool: %w", err)
+		return fmt.Errorf("register draft tool: %w", err)
+	}
+
+	err = server.RegisterTool("tg_send", "Send message to dialog", client.SendMessage)
+	if err != nil {
+		return fmt.Errorf("register send tool: %w", err)
 	}
 
 	err = server.RegisterTool("tg_read", "Mark dialog messages as read", client.ReadHistory)


### PR DESCRIPTION
Adds real message sending capability and improves proxy support.

## Changes

- **`tg_send` tool**: Send actual messages via `messages.sendMessage` with `crypto/rand` RandomID and `reply_to` support
- **`tg_draft` tool**: Renamed from the old `tg_send` — `SaveDraft` functionality preserved as a separate, clearly named tool
- **Proxy support in auth**: Use `OptionsFromEnvironment` so proxy settings (e.g. `HTTPS_PROXY`) are picked up during authentication

## Motivation

The original `tg_send` only saved drafts, which was confusing. This PR:
1. Adds actual message sending (the most requested capability for AI assistant integrations)
2. Renames the draft-only tool to `tg_draft` for clarity
3. Fixes auth to respect proxy environment variables

## Testing

- `go build ./...` passes
- Tested with Claude Code MCP client: sending messages, replying, saving drafts all work correctly